### PR TITLE
fix: exclude library dirs from iCloud sync to prevent conflict copies (v0.1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.3] - 2026-04-11
 
 ### Fixed
 - **macOS iCloud Drive conflict copies** - Re-installing libraries in iCloud-synced directories (e.g. `~/Documents`) could produce spurious `filename 2.sym` duplicate files. iCloud raced to restore "deleted" files while ams-compose wrote fresh copies after cleanup, causing iCloud to treat them as conflicts. Fix: pre-create the library directory and immediately set the `com.apple.fileprovider.ignore#P` extended attribute before copying any files, so iCloud never races against re-installs. No-op on non-macOS platforms.
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PyYAML >=6.0.0 - YAML configuration parsing
 - pathspec >=0.11.0 - Gitignore pattern matching
 
+[0.1.3]: https://github.com/Jianxun/ams-compose/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/Jianxun/ams-compose/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/Jianxun/ams-compose/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/Jianxun/ams-compose/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **macOS iCloud Drive conflict copies** - Re-installing libraries in iCloud-synced directories (e.g. `~/Documents`) could produce spurious `filename 2.sym` duplicate files. iCloud raced to restore "deleted" files while ams-compose wrote fresh copies after cleanup, causing iCloud to treat them as conflicts. Fix: pre-create the library directory and immediately set the `com.apple.fileprovider.ignore#P` extended attribute before copying any files, so iCloud never races against re-installs. No-op on non-macOS platforms.
+
 ## [0.1.2] - 2026-03-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -250,6 +250,27 @@ ams-compose schema
 ams-compose clean
 ```
 
+**Duplicate files with ` 2` suffix on macOS (e.g. `amplifier 2.sym`)**
+
+This happens when the project lives in an iCloud Drive-synced directory (such as
+`~/Documents`). iCloud races to restore "deleted" files while ams-compose writes
+fresh copies during a re-install, and resolves the conflict by appending ` 2` to
+the restored filenames.
+
+ams-compose (v0.1.3+) automatically sets the `com.apple.fileprovider.ignore#P`
+extended attribute on each library directory immediately after creation, which
+signals iCloud to stop syncing that path. No manual action is needed for new
+installs.
+
+If you have leftover ` 2` files from a previous install, remove them manually:
+```bash
+find designs/libs -name "* 2*" -exec rm -rf {} +
+```
+Then reinstall to get a clean state:
+```bash
+ams-compose install --force
+```
+
 **Path or permission issues**
 - Ensure write permissions to `library_root` directory
 - Verify git credentials for private repositories

--- a/ams_compose/__init__.py
+++ b/ams_compose/__init__.py
@@ -1,5 +1,5 @@
 """ams-compose: Dependency management for analog IC design repositories."""
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 __author__ = "ams-compose contributors"
 __description__ = "Dependency management tool for analog/mixed-signal IC design repositories"

--- a/ams_compose/core/extractor.py
+++ b/ams_compose/core/extractor.py
@@ -1,6 +1,8 @@
 """Path extraction operations for ams-compose."""
 
 import shutil
+import subprocess
+import sys
 from pathlib import Path
 from typing import Optional, Dict, Callable, Set, List
 from dataclasses import dataclass
@@ -12,6 +14,31 @@ from .config import ImportSpec
 from ..utils.checksum import ChecksumCalculator
 from ..utils.license import LicenseDetector
 from .. import __version__
+
+
+def _exclude_from_icloud_sync(path: Path) -> None:
+    """Exclude a path from iCloud Drive sync on macOS.
+
+    Sets the com.apple.fileprovider.ignore#P extended attribute, which signals
+    iCloud Drive to stop syncing this path. This prevents conflict copies
+    (e.g. 'amplifier 2.sym') when re-installing libraries stored in iCloud-synced
+    directories such as ~/Documents.
+
+    No-op on non-macOS platforms or if xattr is unavailable.
+
+    Args:
+        path: Directory to exclude from iCloud sync
+    """
+    if sys.platform != 'darwin':
+        return
+    try:
+        subprocess.run(
+            ['xattr', '-w', 'com.apple.fileprovider.ignore#P', '1', str(path)],
+            capture_output=True,
+            check=False
+        )
+    except Exception:
+        pass  # Best-effort; never fail an installation over sync exclusion
 
 
 @dataclass
@@ -434,6 +461,14 @@ class PathExtractor:
         try:
             # Copy source to destination
             if source_full_path.is_dir():
+                # Pre-create directory and immediately exclude from iCloud sync.
+                # Setting the xattr before any files land prevents iCloud from
+                # racing to restore "deleted" files as conflict copies (e.g.
+                # 'amplifier 2.sym') when re-installing in ~/Documents or other
+                # iCloud-synced directories.
+                local_path.mkdir()
+                _exclude_from_icloud_sync(local_path)
+
                 # Create ignore function with three-tier filtering
                 # Preserve LICENSE files for legal compliance
                 # Force preservation when checkin=True, respect user patterns when checkin=False
@@ -442,14 +477,14 @@ class PathExtractor:
                     preserve_license_files=True,
                     force_preserve_license=import_spec.checkin
                 )
-                
+
                 shutil.copytree(
-                    source_full_path, 
+                    source_full_path,
                     local_path,
                     symlinks=True,  # Preserve symlinks
                     ignore_dangling_symlinks=True,
                     ignore=ignore_func,  # Apply three-tier filtering
-                    dirs_exist_ok=False  # Should not exist due to cleanup above
+                    dirs_exist_ok=True  # Pre-created above for iCloud exclusion
                 )
             else:
                 # Single file - copy to parent directory with same name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ams-compose"
-version = "0.1.2"
+version = "0.1.3"
 description = "Dependency management tool for analog/mixed-signal IC design repositories"
 authors = [
     {name = "ams-compose contributors"}

--- a/tests/unit/core/test_extractor_extraction.py
+++ b/tests/unit/core/test_extractor_extraction.py
@@ -1,13 +1,14 @@
 """Unit tests for PathExtractor extraction operations."""
 
+import sys
 import tempfile
 import shutil
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, call
 
 import pytest
 
-from ams_compose.core.extractor import PathExtractor, ExtractionState
+from ams_compose.core.extractor import PathExtractor, ExtractionState, _exclude_from_icloud_sync
 from ams_compose.core.config import ImportSpec
 from ams_compose.utils.checksum import ChecksumCalculator
 
@@ -431,6 +432,58 @@ class TestExtractionOperations:
         assert 'readme.txt' not in ignored
         assert 'normal_file.txt' not in ignored
     
+    # --- iCloud sync exclusion tests ---
+
+    def test_extract_library_calls_icloud_exclusion(self):
+        """Test that extract_library excludes the library directory from iCloud sync."""
+        import_spec = ImportSpec(
+            repo="https://example.com/repo",
+            ref="main",
+            source_path="libs/test_lib"
+        )
+
+        with patch('ams_compose.core.extractor._exclude_from_icloud_sync') as mock_exclude:
+            self.extractor.extract_library(
+                library_name="test_lib",
+                import_spec=import_spec,
+                mirror_path=self.mock_mirror,
+                library_root="designs/libs",
+                repo_hash="abcd1234",
+                resolved_commit="commit123456"
+            )
+
+        local_path = (self.project_root / "designs" / "libs" / "test_lib").resolve()
+        mock_exclude.assert_called_once_with(local_path)
+
+    def test_exclude_from_icloud_sync_calls_xattr_on_macos(self):
+        """Test that _exclude_from_icloud_sync runs xattr on macOS."""
+        test_path = Path("/some/library")
+        with patch('sys.platform', 'darwin'), \
+             patch('subprocess.run') as mock_run:
+            _exclude_from_icloud_sync(test_path)
+
+        mock_run.assert_called_once_with(
+            ['xattr', '-w', 'com.apple.fileprovider.ignore#P', '1', '/some/library'],
+            capture_output=True,
+            check=False
+        )
+
+    def test_exclude_from_icloud_sync_noop_on_linux(self):
+        """Test that _exclude_from_icloud_sync is a no-op on non-macOS platforms."""
+        test_path = Path("/some/library")
+        with patch('sys.platform', 'linux'), \
+             patch('subprocess.run') as mock_run:
+            _exclude_from_icloud_sync(test_path)
+
+        mock_run.assert_not_called()
+
+    def test_exclude_from_icloud_sync_swallows_xattr_error(self):
+        """Test that _exclude_from_icloud_sync never raises even if xattr fails."""
+        test_path = Path("/some/library")
+        with patch('sys.platform', 'darwin'), \
+             patch('subprocess.run', side_effect=FileNotFoundError("xattr not found")):
+            _exclude_from_icloud_sync(test_path)  # must not raise
+
     def test_ignore_function_with_custom_hook(self):
         """Test the _create_ignore_function with custom ignore hook."""
         # Create custom hook that ignores backup files


### PR DESCRIPTION
## Summary

- **Root cause**: Re-installing libraries in iCloud Drive-synced directories (e.g. `~/Documents`) produced spurious `filename 2.sym` duplicate files. iCloud raced to restore "deleted" files while ams-compose wrote fresh copies after `shutil.rmtree`, treating them as conflicts.
- **Fix**: Pre-create the library directory and immediately set `com.apple.fileprovider.ignore#P` xattr before copying any files — iCloud sees the exclusion flag before the first file lands and never races against re-installs.
- **Scope**: macOS only; no-op on Linux/Windows. Best-effort (never fails an install).

## Changes

- `ams_compose/core/extractor.py`: add `_exclude_from_icloud_sync()`, pre-create dir + set xattr before `shutil.copytree`, switch to `dirs_exist_ok=True`
- `tests/unit/core/test_extractor_extraction.py`: 4 new tests (macOS path, Linux no-op, error swallowed, called from `extract_library`)
- `CHANGELOG.md` / `README.md`: document the fix and add troubleshooting entry with cleanup instructions for pre-fix installs
- Version bump to **0.1.3**

## Test plan

- [x] 206 unit tests passing (4 new)
- [x] Verified on `iic-osic-tools-project-template` (iCloud-synced `~/Documents`): xattr confirmed present after install, force-reinstall produced 0 conflict files

🤖 Generated with [Claude Code](https://claude.com/claude-code)